### PR TITLE
ci: fix Lint (ruff format + PLC0415)

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -58,4 +58,5 @@ max-complexity = 25
     "ANN",    # type annotations
     "UP017",  # datetime.UTC alias (test files may use timezone.utc for clarity)
     "PLR0913", # many fixture args is normal for pytest fixtures
+    "PLC0415", # deliberate lazy imports inside fixtures (keep heavy imports out of discovery)
 ]

--- a/custom_components/retroarchievements/__init__.py
+++ b/custom_components/retroarchievements/__init__.py
@@ -55,7 +55,9 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     if unload_ok:
         hass.data[DOMAIN].pop(entry.entry_id, None)
         # remove service when no entries remain
-        remaining = [v for v in hass.data.get(DOMAIN, {}).values() if isinstance(v, dict)]
+        remaining = [
+            v for v in hass.data.get(DOMAIN, {}).values() if isinstance(v, dict)
+        ]
         if not remaining and hass.services.has_service(DOMAIN, SERVICE_REFRESH):
             hass.services.async_remove(DOMAIN, SERVICE_REFRESH)
     return unload_ok

--- a/custom_components/retroarchievements/binary_sensor.py
+++ b/custom_components/retroarchievements/binary_sensor.py
@@ -85,9 +85,7 @@ class RetroAchievementsIsGamingBinarySensor(CoordinatorEntity, BinarySensorEntit
         return (now - last).total_seconds() <= threshold_seconds
 
 
-class RetroAchievementsAOTWUnlockedBinarySensor(
-    CoordinatorEntity, BinarySensorEntity
-):
+class RetroAchievementsAOTWUnlockedBinarySensor(CoordinatorEntity, BinarySensorEntity):
     """Binary sensor that is ON when the user has unlocked the current AOTW."""
 
     _attr_has_entity_name = True

--- a/custom_components/retroarchievements/coordinator.py
+++ b/custom_components/retroarchievements/coordinator.py
@@ -88,9 +88,7 @@ class RetroAchievementsDataUpdateCoordinator(DataUpdateCoordinator):
                     return achievements[ach_id], None
         return None, None
 
-    def _build_enriched_payload(
-        self, ach: dict, game_id: int, game_ext: dict
-    ) -> dict:
+    def _build_enriched_payload(self, ach: dict, game_id: int, game_ext: dict) -> dict:
         """Build the enriched event payload for an unlocked achievement."""
         ach_id = ach.get("ID")
         badge = ach.get("BadgeName")
@@ -206,9 +204,7 @@ class RetroAchievementsDataUpdateCoordinator(DataUpdateCoordinator):
                 "console_id": award.get("ConsoleID"),
                 "awarded_at": award.get("AwardedAt"),
                 "hardcore": award.get("AwardDataExtra") == 1,
-                "image_url": (
-                    f"https://retroachievements.org{icon}" if icon else None
-                ),
+                "image_url": (f"https://retroachievements.org{icon}" if icon else None),
                 "username": self.api_client.username,
             },
         )
@@ -288,9 +284,7 @@ class RetroAchievementsDataUpdateCoordinator(DataUpdateCoordinator):
             LOGGER.error("Unexpected error fetching retroachievements data: %s", error)
             raise
 
-    async def _fire_achievement_unlocked(
-        self, ach_id: int, user_summary: dict
-    ) -> None:
+    async def _fire_achievement_unlocked(self, ach_id: int, user_summary: dict) -> None:
         """Look up, enrich, and fire the achievement_unlocked event."""
         ach, game_id = self._find_achievement(ach_id, user_summary)
         if ach is None or game_id is None:
@@ -332,7 +326,7 @@ class RetroAchievementsDataUpdateCoordinator(DataUpdateCoordinator):
         """Return True if the user already unlocked the current AOTW."""
         if not self.data:
             return False
-        aotw = (self.data.get("aotw") or {})
+        aotw = self.data.get("aotw") or {}
         ach_id = (aotw.get("Achievement") or {}).get("ID")
         if not ach_id:
             return False
@@ -342,9 +336,7 @@ class RetroAchievementsDataUpdateCoordinator(DataUpdateCoordinator):
             return False
         if ach_id_int in self._previous_achievement_ids:
             return True
-        recent = (self.data.get("user_summary") or {}).get(
-            "RecentAchievements"
-        ) or {}
+        recent = (self.data.get("user_summary") or {}).get("RecentAchievements") or {}
         for _game_id, achievements in recent.items():
             if not isinstance(achievements, dict):
                 continue

--- a/custom_components/retroarchievements/sensor.py
+++ b/custom_components/retroarchievements/sensor.py
@@ -24,6 +24,7 @@ from .const import (
     ATTR_POINTS_TOTAL,
     CONF_USERNAME,
     DOMAIN,
+    LOGGER,
 )
 from .coordinator import RetroAchievementsDataUpdateCoordinator
 
@@ -493,8 +494,6 @@ class RetroAchievementsRecentlyPlayedSensor(RetroAchievementsBaseSensor):
         self._game_id = game_data.get("GameID")
         self._game_title = game_data.get("Title")
         self._console_name = game_data.get("ConsoleName")
-
-        from .const import LOGGER
 
         LOGGER.debug(
             "Creating recently played sensor for game: %s (ID: %s, Console: %s)",

--- a/custom_components/retroarchievements/todo.py
+++ b/custom_components/retroarchievements/todo.py
@@ -23,9 +23,7 @@ async def async_setup_entry(
     coordinator: RetroAchievementsDataUpdateCoordinator = hass.data[DOMAIN][
         entry.entry_id
     ]["coordinator"]
-    async_add_entities(
-        [RetroAchievementsWantToPlayTodoList(coordinator, username)]
-    )
+    async_add_entities([RetroAchievementsWantToPlayTodoList(coordinator, username)])
 
 
 class RetroAchievementsWantToPlayTodoList(CoordinatorEntity, TodoListEntity):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 """Shared pytest fixtures."""
+
 from __future__ import annotations
 
 import json
@@ -79,16 +80,14 @@ def mock_api_client(
     client.username = "TestUser"
     client._username = "TestUser"
     client.async_get_user_summary.return_value = user_summary_fixture
-    client.async_get_user_recent_games.return_value = (
-        user_summary_fixture.get("RecentlyPlayed", [])
+    client.async_get_user_recent_games.return_value = user_summary_fixture.get(
+        "RecentlyPlayed", []
     )
     client.async_get_achievement_of_the_week.return_value = aotw_fixture
     client.async_get_game_extended.return_value = game_extended_fixture
     client.async_get_user_progress.return_value = {}
     client.async_get_user_points.return_value = user_points_fixture
-    client.async_get_user_completion_progress.return_value = (
-        completion_progress_fixture
-    )
+    client.async_get_user_completion_progress.return_value = completion_progress_fixture
     client.async_get_user_awards.return_value = user_awards_fixture
     client.async_get_user_want_to_play_list.return_value = want_to_play_fixture
     return client

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,4 +1,5 @@
 """Tests for the RetroAchievements API client."""
+
 from __future__ import annotations
 
 import re
@@ -20,9 +21,7 @@ async def session():
         yield s
 
 
-async def test_get_achievement_of_the_week_returns_payload(
-    session, aotw_fixture
-):
+async def test_get_achievement_of_the_week_returns_payload(session, aotw_fixture):
     url = re.compile(rf"^{re.escape(BASE_URL)}API_GetAchievementOfTheWeek\.php")
     with aioresponses() as m:
         m.get(url, payload=aotw_fixture)

--- a/tests/test_api_new_endpoints.py
+++ b/tests/test_api_new_endpoints.py
@@ -1,4 +1,5 @@
 """Tests for the RetroAchievements API client's expanded endpoints."""
+
 from __future__ import annotations
 
 import re

--- a/tests/test_binary_sensor_aotw_unlocked.py
+++ b/tests/test_binary_sensor_aotw_unlocked.py
@@ -1,4 +1,5 @@
 """Tests for the aotw_unlocked binary sensor."""
+
 from __future__ import annotations
 
 import pytest
@@ -23,9 +24,7 @@ def mock_entry():
     )
 
 
-async def test_aotw_unlocked_true(
-    hass, mock_api_client, mock_entry, aotw_fixture
-):
+async def test_aotw_unlocked_true(hass, mock_api_client, mock_entry, aotw_fixture):
     aotw = {
         **aotw_fixture,
         "Achievement": {**aotw_fixture["Achievement"], "ID": 12345},

--- a/tests/test_binary_sensor_is_gaming.py
+++ b/tests/test_binary_sensor_is_gaming.py
@@ -1,4 +1,5 @@
 """Tests for the is_gaming binary sensor."""
+
 from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone

--- a/tests/test_config_flow_options.py
+++ b/tests/test_config_flow_options.py
@@ -1,4 +1,5 @@
 """Tests for the options flow with gaming_idle_threshold."""
+
 from __future__ import annotations
 
 import pytest
@@ -23,7 +24,9 @@ def mock_entry(hass):
     return entry
 
 
-async def test_options_flow_accepts_idle_threshold(hass, mock_entry, enable_custom_integrations):
+async def test_options_flow_accepts_idle_threshold(
+    hass, mock_entry, enable_custom_integrations
+):
     result = await hass.config_entries.options.async_init(mock_entry.entry_id)
     assert result["type"] == "form"
     result2 = await hass.config_entries.options.async_configure(
@@ -34,7 +37,9 @@ async def test_options_flow_accepts_idle_threshold(hass, mock_entry, enable_cust
     assert result2["data"][CONF_GAMING_IDLE_THRESHOLD] == 10
 
 
-async def test_options_flow_rejects_threshold_too_high(hass, mock_entry, enable_custom_integrations):
+async def test_options_flow_rejects_threshold_too_high(
+    hass, mock_entry, enable_custom_integrations
+):
     result = await hass.config_entries.options.async_init(mock_entry.entry_id)
     with pytest.raises(InvalidData):
         await hass.config_entries.options.async_configure(

--- a/tests/test_config_flow_reauth.py
+++ b/tests/test_config_flow_reauth.py
@@ -1,4 +1,5 @@
 """Tests for the reauth config flow."""
+
 from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
@@ -30,15 +31,19 @@ async def test_reauth_success_updates_key(hass, mock_entry, enable_custom_integr
     assert result["type"] == "form"
     assert result["step_id"] == "reauth_confirm"
 
-    with patch(
-        "custom_components.retroarchievements.config_flow."
-        "RetroAchievementsApiClient.async_get_user_summary",
-        return_value={"User": "TestUser"},
-    ), patch(
-        "custom_components.retroarchievements.config_flow."
-        "async_create_clientsession",
-        return_value=MagicMock(),
-    ), patch.object(hass.config_entries, "async_schedule_reload"):
+    with (
+        patch(
+            "custom_components.retroarchievements.config_flow."
+            "RetroAchievementsApiClient.async_get_user_summary",
+            return_value={"User": "TestUser"},
+        ),
+        patch(
+            "custom_components.retroarchievements.config_flow."
+            "async_create_clientsession",
+            return_value=MagicMock(),
+        ),
+        patch.object(hass.config_entries, "async_schedule_reload"),
+    ):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"], user_input={CONF_API_KEY: "newkey"}
         )
@@ -53,14 +58,17 @@ async def test_reauth_invalid_key_shows_error(
 ):
     result = await mock_entry.start_reauth_flow(hass)
 
-    with patch(
-        "custom_components.retroarchievements.config_flow."
-        "RetroAchievementsApiClient.async_get_user_summary",
-        side_effect=RetroAchievementsApiClientAuthenticationError("bad"),
-    ), patch(
-        "custom_components.retroarchievements.config_flow."
-        "async_create_clientsession",
-        return_value=MagicMock(),
+    with (
+        patch(
+            "custom_components.retroarchievements.config_flow."
+            "RetroAchievementsApiClient.async_get_user_summary",
+            side_effect=RetroAchievementsApiClientAuthenticationError("bad"),
+        ),
+        patch(
+            "custom_components.retroarchievements.config_flow."
+            "async_create_clientsession",
+            return_value=MagicMock(),
+        ),
     ):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"], user_input={CONF_API_KEY: "stillbad"}

--- a/tests/test_coordinator_events.py
+++ b/tests/test_coordinator_events.py
@@ -1,4 +1,5 @@
 """Tests for coordinator event firing (achievement_unlocked, aotw_changed)."""
+
 from __future__ import annotations
 
 import pytest
@@ -24,18 +25,14 @@ def mock_entry():
     )
 
 
-async def test_first_run_does_not_fire_events(
-    hass, mock_api_client, mock_entry
-):
+async def test_first_run_does_not_fire_events(hass, mock_api_client, mock_entry):
     """On the very first refresh, neither event type fires."""
     fired_achievement = []
     fired_aotw = []
     hass.bus.async_listen(
         EVENT_ACHIEVEMENT_UNLOCKED, lambda e: fired_achievement.append(e)
     )
-    hass.bus.async_listen(
-        EVENT_AOTW_CHANGED, lambda e: fired_aotw.append(e)
-    )
+    hass.bus.async_listen(EVENT_AOTW_CHANGED, lambda e: fired_aotw.append(e))
     coord = RetroAchievementsDataUpdateCoordinator(hass, mock_api_client, mock_entry)
     await coord.async_refresh()
     await hass.async_block_till_done()
@@ -93,9 +90,7 @@ async def test_new_achievement_fires_event_with_enriched_payload(
     assert payload["rarity_pct"] is None  # 12346 not in game_extended fixture
 
 
-async def test_no_new_achievements_fires_no_events(
-    hass, mock_api_client, mock_entry
-):
+async def test_no_new_achievements_fires_no_events(hass, mock_api_client, mock_entry):
     fired = []
     hass.bus.async_listen(EVENT_ACHIEVEMENT_UNLOCKED, lambda e: fired.append(e))
     coord = RetroAchievementsDataUpdateCoordinator(hass, mock_api_client, mock_entry)
@@ -105,9 +100,7 @@ async def test_no_new_achievements_fires_no_events(
     assert fired == []
 
 
-async def test_aotw_change_fires_event(
-    hass, mock_api_client, mock_entry, aotw_fixture
-):
+async def test_aotw_change_fires_event(hass, mock_api_client, mock_entry, aotw_fixture):
     fired = []
     hass.bus.async_listen(EVENT_AOTW_CHANGED, lambda e: fired.append(e))
     coord = RetroAchievementsDataUpdateCoordinator(hass, mock_api_client, mock_entry)

--- a/tests/test_coordinator_helpers.py
+++ b/tests/test_coordinator_helpers.py
@@ -1,4 +1,5 @@
 """Tests for pure-logic helpers on the coordinator."""
+
 from __future__ import annotations
 
 from custom_components.retroarchievements.coordinator import (
@@ -25,9 +26,7 @@ def test_extract_achievement_ids_from_recent_achievements():
 
 
 def test_extract_achievement_ids_empty_input():
-    assert (
-        RetroAchievementsDataUpdateCoordinator._extract_achievement_ids({}) == set()
-    )
+    assert RetroAchievementsDataUpdateCoordinator._extract_achievement_ids({}) == set()
     assert (
         RetroAchievementsDataUpdateCoordinator._extract_achievement_ids(
             {"RecentAchievements": None}
@@ -38,9 +37,7 @@ def test_extract_achievement_ids_empty_input():
 
 def test_extract_achievement_ids_skips_non_integer_keys():
     user_summary = {
-        "RecentAchievements": {
-            "678": {"abc": {"ID": 0}, "12345": {"ID": 12345}}
-        }
+        "RecentAchievements": {"678": {"abc": {"ID": 0}, "12345": {"ID": 12345}}}
     }
     result = RetroAchievementsDataUpdateCoordinator._extract_achievement_ids(
         user_summary

--- a/tests/test_coordinator_is_aotw_unlocked.py
+++ b/tests/test_coordinator_is_aotw_unlocked.py
@@ -1,4 +1,5 @@
 """Tests for RetroAchievementsDataUpdateCoordinator.is_aotw_unlocked."""
+
 from __future__ import annotations
 
 import pytest

--- a/tests/test_coordinator_new_data.py
+++ b/tests/test_coordinator_new_data.py
@@ -1,4 +1,5 @@
 """Tests for the coordinator's expanded data fetch + award_earned event."""
+
 from __future__ import annotations
 
 import pytest
@@ -77,7 +78,9 @@ async def test_new_award_fires_event(
     assert payload["award_type"] == "Mastery/Completion"
     assert payload["hardcore"] is True
     assert payload["console_name"] == "Mega Drive"
-    assert payload["image_url"] == "https://retroachievements.org/Images/aladdin-icon.png"
+    assert (
+        payload["image_url"] == "https://retroachievements.org/Images/aladdin-icon.png"
+    )
 
 
 async def test_unchanged_awards_fire_no_event(hass, mock_api_client, mock_entry):

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -1,4 +1,5 @@
 """Tests for config entry diagnostics."""
+
 from __future__ import annotations
 
 import pytest

--- a/tests/test_image_todo_button.py
+++ b/tests/test_image_todo_button.py
@@ -1,4 +1,5 @@
 """Tests for the image, todo, and button platforms."""
+
 from __future__ import annotations
 
 from unittest.mock import AsyncMock
@@ -41,10 +42,7 @@ async def _coordinator(hass, mock_api_client, mock_entry):
 async def test_box_art_image_url(hass, mock_api_client, mock_entry):
     coord = await _coordinator(hass, mock_api_client, mock_entry)
     entity = RetroAchievementsBoxArtImage(hass, coord, "TestUser")
-    assert (
-        entity.image_url
-        == "https://retroachievements.org/Images/sonic-box.png"
-    )
+    assert entity.image_url == "https://retroachievements.org/Images/sonic-box.png"
 
 
 async def test_last_badge_image_url(hass, mock_api_client, mock_entry):

--- a/tests/test_sensor_aotw.py
+++ b/tests/test_sensor_aotw.py
@@ -1,4 +1,5 @@
 """Tests for the AOTW sensor."""
+
 from __future__ import annotations
 
 import pytest
@@ -23,9 +24,7 @@ def mock_entry():
     )
 
 
-async def test_aotw_sensor_state_and_attributes(
-    hass, mock_api_client, mock_entry
-):
+async def test_aotw_sensor_state_and_attributes(hass, mock_api_client, mock_entry):
     coord = RetroAchievementsDataUpdateCoordinator(hass, mock_api_client, mock_entry)
     await coord.async_refresh()
     sensor = RetroAchievementsAOTWSensor(coord, "TestUser")

--- a/tests/test_sensor_stats.py
+++ b/tests/test_sensor_stats.py
@@ -1,4 +1,5 @@
 """Tests for the expanded user-stat sensors."""
+
 from __future__ import annotations
 
 import pytest

--- a/tests/test_service_refresh.py
+++ b/tests/test_service_refresh.py
@@ -1,4 +1,5 @@
 """Tests for the retroarchievements.refresh service."""
+
 from __future__ import annotations
 
 from unittest.mock import AsyncMock, patch


### PR DESCRIPTION
The **Lint** workflow has been failing on \`main\` since the ruff `0.13.0` bump (#33, Sep 2025) — every push since has a red Lint check.

## Fixes
- \`ruff format .\` (pinned `0.13.0`) — 20 files reformatted.
- `sensor.py`: move `from .const import LOGGER` to module top (PLC0415).
- `.ruff.toml`: ignore `PLC0415` for `tests/*` (deliberate lazy imports in fixtures).

## Verification
- `ruff check .` → All checks passed.
- `ruff format . --check` → 30 files already formatted.
- Test suite green (59 passed; the lone `test_api` teardown error is a pre-existing aiohttp shutdown-thread leak).

Pure tooling/formatting — no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)