### PR TITLE
ci: bump actions/setup-python to v6.2.0 (Node 24)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,7 +19,7 @@ jobs:
           uses: "actions/checkout@v5.0.0"
 
         - name: "Set up Python"
-          uses: actions/setup-python@v5.6.0
+          uses: actions/setup-python@v6.2.0
           with:
             python-version: "3.13"
             cache: "pip"


### PR DESCRIPTION
GitHub flagged `actions/setup-python@v5.6.0` as a Node 20 action (forced to Node 24 on 2026-06-02, removed 2026-09-16). Bumps to `v6.2.0`, which runs on Node 24. Same `python-version` / `cache` API — no other changes.

`actions/checkout@v5.0.0` already runs on Node 24, so it's left as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)