### PR TITLE
feat: calendar, derived sensors, per-game rank/score & console-game picker

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,16 @@ Sourced from the RetroAchievements `GetUserPoints`, `GetUserCompletionProgress`,
 | `sensor.retroachievements_USERNAME_games_beaten` | Number of games beaten (hardcore + softcore) |
 | `sensor.retroachievements_USERNAME_games_played` | Number of games played |
 | `sensor.retroachievements_USERNAME_awards_total` | Total site awards earned |
+| `sensor.retroachievements_USERNAME_want_to_play_count` | Number of games in your "Want to Play" backlog (attributes: full game list) |
+| `sensor.retroachievements_USERNAME_last_achievement` | Title of your most recently unlocked achievement (attributes: id, description, points, game, date, badge URL) |
+
+### Calendar
+
+Sourced from the `GetAchievementsEarnedBetween` endpoint (trailing 14 days).
+
+| Entity | Description |
+|--------|-------------|
+| `calendar.retroachievements_USERNAME_achievements` | One event per achievement unlocked over the last 14 days |
 
 ### Image, Todo & Button Entities
 
@@ -120,6 +130,10 @@ All game sensors are grouped under your RetroAchievements user device for easy o
 - `points_earned`: Points earned
 - `completion_percentage`: Game completion percentage
 - `recent_achievements`: List of recently unlocked achievements for this game
+- `leaderboards`: Your leaderboard entries for the game (monitored games)
+- `user_rank`: Your rank within the game, from `GetUserGameRankAndScore` (monitored games)
+- `user_total_score`: Your total score within the game (monitored games)
+- `last_award`: Timestamp of your most recent award in the game (monitored games)
 
 ## Use Cases
 

--- a/README.md
+++ b/README.md
@@ -87,6 +87,15 @@ For each recently played game, the integration creates:
 
 All game sensors are grouped under your RetroAchievements user device for easy organization.
 
+### Monitoring specific games
+
+Open the integration's **Configure** dialog to pick which games to monitor:
+
+- **Select games to monitor** — choose a console, then multi-select its games from a searchable dropdown (only games that have achievements are listed). Selecting games for one console keeps games already chosen on other consoles.
+- **Edit game IDs & settings** — edit the raw newline-separated game ID list directly (useful for removal or bulk edits) and set the gaming idle threshold.
+
+Monitored games gain progress, leaderboard, and rank/score data.
+
 ## Attributes
 
 ### User Profile Attributes

--- a/custom_components/retroarchievements/api.py
+++ b/custom_components/retroarchievements/api.py
@@ -251,6 +251,22 @@ class RetroAchievementsApiClient:
         )
         return response if isinstance(response, list) else []
 
+    async def async_get_console_ids(self) -> list[dict[str, Any]]:
+        """Get the list of console/system IDs (active game systems only)."""
+        response = await self._api_wrapper(
+            endpoint="API_GetConsoleIDs.php",
+            params={"a": 1, "g": 1, "y": self._api_key},
+        )
+        return response if isinstance(response, list) else []
+
+    async def async_get_game_list(self, console_id: int) -> list[dict[str, Any]]:
+        """Get games (with achievements) for a console."""
+        response = await self._api_wrapper(
+            endpoint="API_GetGameList.php",
+            params={"i": console_id, "f": 1, "h": 0, "y": self._api_key},
+        )
+        return response if isinstance(response, list) else []
+
     async def async_get_achievements_earned_between(
         self, from_date: str, to_date: str
     ) -> list[dict[str, Any]]:

--- a/custom_components/retroarchievements/api.py
+++ b/custom_components/retroarchievements/api.py
@@ -237,6 +237,35 @@ class RetroAchievementsApiClient:
         )
         return response if isinstance(response, dict) else {}
 
+    async def async_get_user_game_rank_and_score(
+        self, game_id: int
+    ) -> list[dict[str, Any]]:
+        """Get the user's rank and score within a specific game."""
+        response = await self._api_wrapper(
+            endpoint="API_GetUserGameRankAndScore.php",
+            params={
+                "g": game_id,
+                "u": self._username,
+                "y": self._api_key,
+            },
+        )
+        return response if isinstance(response, list) else []
+
+    async def async_get_achievements_earned_between(
+        self, from_date: str, to_date: str
+    ) -> list[dict[str, Any]]:
+        """Get achievements the user earned between two dates (YYYY-MM-DD)."""
+        response = await self._api_wrapper(
+            endpoint="API_GetAchievementsEarnedBetween.php",
+            params={
+                "u": self._username,
+                "f": from_date,
+                "t": to_date,
+                "y": self._api_key,
+            },
+        )
+        return response if isinstance(response, list) else []
+
     async def _api_wrapper(
         self,
         endpoint: str,

--- a/custom_components/retroarchievements/calendar.py
+++ b/custom_components/retroarchievements/calendar.py
@@ -1,0 +1,126 @@
+"""RetroAchievements calendar platform: recent unlocks as calendar events."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+from homeassistant.components.calendar import CalendarEntity, CalendarEvent
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+from homeassistant.util import dt as dt_util
+
+from .const import CONF_USERNAME, DOMAIN
+from .coordinator import RetroAchievementsDataUpdateCoordinator
+
+# Coordinator already fetches everything; entity reads are local. No throttling.
+PARALLEL_UPDATES = 0
+
+# Each unlock is rendered as a short event of this duration.
+_EVENT_DURATION = timedelta(minutes=30)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the RetroAchievements calendar based on a config entry."""
+    username = entry.data[CONF_USERNAME]
+    coordinator = entry.runtime_data
+    async_add_entities([RetroAchievementsAchievementsCalendar(coordinator, username)])
+
+
+def _parse_award_dt(value: str | None) -> datetime | None:
+    """Parse a RetroAchievements unlock timestamp into an aware datetime."""
+    if not value:
+        return None
+    parsed = dt_util.parse_datetime(str(value))
+    if parsed is None:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=dt_util.DEFAULT_TIME_ZONE)
+    return parsed
+
+
+class RetroAchievementsAchievementsCalendar(CoordinatorEntity, CalendarEntity):
+    """Calendar of recently unlocked achievements."""
+
+    _attr_has_entity_name = True
+    _attr_translation_key = "achievements"
+    _attr_icon = "mdi:calendar-check"
+
+    def __init__(
+        self,
+        coordinator: RetroAchievementsDataUpdateCoordinator,
+        username: str,
+    ) -> None:
+        """Initialize the calendar."""
+        super().__init__(coordinator)
+        self.username = username
+        self._attr_unique_id = f"{DOMAIN}_{username}_achievements_calendar"
+        self._attr_device_info = DeviceInfo(
+            entry_type=DeviceEntryType.SERVICE,
+            identifiers={(DOMAIN, f"{username}")},
+            manufacturer="RetroAchievements",
+            name=f"RetroAchievements {username}",
+            configuration_url=f"https://retroachievements.org/user/{username}",
+            model="User Profile",
+        )
+
+    @property
+    def available(self) -> bool:
+        """Return if entity is available."""
+        return (
+            self.coordinator.last_update_success and self.coordinator.data is not None
+        )
+
+    def _build_events(self) -> list[CalendarEvent]:
+        """Build calendar events from the coordinator's unlock history."""
+        unlocks = (self.coordinator.data or {}).get("earned_between") or []
+        events: list[CalendarEvent] = []
+        for unlock in unlocks:
+            if not isinstance(unlock, dict):
+                continue
+            start = _parse_award_dt(unlock.get("Date") or unlock.get("DateAwarded"))
+            if start is None:
+                continue
+            game = unlock.get("GameTitle")
+            title = unlock.get("Title") or "Achievement"
+            summary = f"{title} ({game})" if game else title
+            description = unlock.get("Description")
+            points = unlock.get("Points")
+            if points is not None:
+                description = f"{description or ''} [{points} pts]".strip()
+            events.append(
+                CalendarEvent(
+                    start=start,
+                    end=start + _EVENT_DURATION,
+                    summary=summary,
+                    description=description or None,
+                    uid=str(unlock.get("ID")) if unlock.get("ID") else None,
+                )
+            )
+        events.sort(key=lambda event: event.start)
+        return events
+
+    @property
+    def event(self) -> CalendarEvent | None:
+        """Return the most recent unlock event for state display."""
+        events = self._build_events()
+        return events[-1] if events else None
+
+    async def async_get_events(
+        self,
+        hass: HomeAssistant,  # noqa: ARG002
+        start_date: datetime,
+        end_date: datetime,
+    ) -> list[CalendarEvent]:
+        """Return events within the requested time range."""
+        return [
+            event
+            for event in self._build_events()
+            if event.start < end_date and event.end > start_date
+        ]

--- a/custom_components/retroarchievements/config_flow.py
+++ b/custom_components/retroarchievements/config_flow.py
@@ -6,7 +6,10 @@ import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.const import CONF_USERNAME
 from homeassistant.helpers import selector
-from homeassistant.helpers.aiohttp_client import async_create_clientsession
+from homeassistant.helpers.aiohttp_client import (
+    async_create_clientsession,
+    async_get_clientsession,
+)
 
 from .api import (
     RetroAchievementsApiClient,
@@ -22,6 +25,9 @@ from .const import (
     DOMAIN,
     LOGGER,
 )
+
+CONF_CONSOLE = "console"
+CONF_GAMES = "games"
 
 
 class RetroAchievementsFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
@@ -154,19 +160,160 @@ class RetroAchievementsOptionsFlowHandler(config_entries.OptionsFlow):
     def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
         """Initialize options flow."""
         self.config_entry = config_entry
+        raw = config_entry.options.get(CONF_MONITORED_GAMES, "") or ""
+        self._monitored: set[str] = {
+            line.strip() for line in raw.splitlines() if line.strip()
+        }
+        self._idle_threshold: int = config_entry.options.get(
+            CONF_GAMING_IDLE_THRESHOLD, DEFAULT_GAMING_IDLE_THRESHOLD
+        )
+        self._selected_console: str | None = None
+        self._console_games: list[dict] = []
+
+    def _client(self) -> RetroAchievementsApiClient:
+        """Build an API client from the stored credentials."""
+        return RetroAchievementsApiClient(
+            username=self.config_entry.data[CONF_USERNAME],
+            api_key=self.config_entry.data[CONF_API_KEY],
+            session=async_get_clientsession(self.hass),
+        )
+
+    def _serialize_monitored(self) -> str:
+        """Return monitored game IDs as a newline-separated string, numerically sorted."""
+
+        def _key(value: str) -> tuple[int, str]:
+            return (int(value), "") if value.isdigit() else (1 << 62, value)
+
+        return "\n".join(sorted(self._monitored, key=_key))
+
+    def _save(self) -> config_entries.ConfigFlowResult:
+        """Persist the current monitored games and settings."""
+        return self.async_create_entry(
+            title="",
+            data={
+                CONF_MONITORED_GAMES: self._serialize_monitored(),
+                CONF_GAMING_IDLE_THRESHOLD: self._idle_threshold,
+            },
+        )
 
     async def async_step_init(
-        self, user_input: dict | None = None
-    ) -> config_entries.FlowResult:
-        """Manage the options."""
-        if user_input is not None:
-            return self.async_create_entry(title="", data=user_input)
+        self, _user_input: dict | None = None
+    ) -> config_entries.ConfigFlowResult:
+        """Show the options menu."""
+        return self.async_show_menu(
+            step_id="init",
+            menu_options=["select_games", "manage"],
+        )
 
-        # Add game selection to options later
+    async def async_step_select_games(
+        self, user_input: dict | None = None
+    ) -> config_entries.ConfigFlowResult:
+        """Pick a console to browse its games."""
+        try:
+            consoles = await self._client().async_get_console_ids()
+        except Exception as err:  # pylint: disable=broad-except
+            LOGGER.warning("Failed to fetch console list: %s", err)
+            consoles = []
+
+        if not consoles:
+            # No console data available; fall back to manual editing.
+            return await self.async_step_manage(error="cannot_load_games")
+
+        if user_input is not None:
+            self._selected_console = user_input[CONF_CONSOLE]
+            return await self.async_step_pick_games()
+
+        options = [
+            selector.SelectOptionDict(
+                value=str(console.get("ID")),
+                label=console.get("Name") or str(console.get("ID")),
+            )
+            for console in consoles
+            if console.get("ID") is not None
+        ]
+        return self.async_show_form(
+            step_id="select_games",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(CONF_CONSOLE): selector.SelectSelector(
+                        selector.SelectSelectorConfig(
+                            options=options,
+                            mode=selector.SelectSelectorMode.DROPDOWN,
+                            sort=True,
+                        ),
+                    ),
+                },
+            ),
+        )
+
+    async def async_step_pick_games(
+        self, user_input: dict | None = None
+    ) -> config_entries.ConfigFlowResult:
+        """Select which games of the chosen console to monitor."""
+        console_id = self._selected_console
+        try:
+            self._console_games = await self._client().async_get_game_list(
+                int(console_id)
+            )
+        except (ValueError, TypeError):
+            self._console_games = []
+        except Exception as err:  # pylint: disable=broad-except
+            LOGGER.warning(
+                "Failed to fetch game list for console %s: %s", console_id, err
+            )
+            self._console_games = []
+
+        console_game_ids = {
+            str(game.get("ID")) for game in self._console_games if game.get("ID")
+        }
+
+        if user_input is not None:
+            selected = {str(g) for g in user_input.get(CONF_GAMES, [])}
+            # Replace only this console's games; keep games from other consoles.
+            self._monitored = (self._monitored - console_game_ids) | selected
+            return self._save()
+
+        options = [
+            selector.SelectOptionDict(
+                value=str(game.get("ID")),
+                label=game.get("Title") or str(game.get("ID")),
+            )
+            for game in self._console_games
+            if game.get("ID") is not None
+        ]
+        current = sorted(self._monitored & console_game_ids)
+        return self.async_show_form(
+            step_id="pick_games",
+            data_schema=vol.Schema(
+                {
+                    vol.Optional(CONF_GAMES, default=current): selector.SelectSelector(
+                        selector.SelectSelectorConfig(
+                            options=options,
+                            mode=selector.SelectSelectorMode.DROPDOWN,
+                            multiple=True,
+                            sort=True,
+                        ),
+                    ),
+                },
+            ),
+        )
+
+    async def async_step_manage(
+        self, user_input: dict | None = None, error: str | None = None
+    ) -> config_entries.ConfigFlowResult:
+        """Edit the raw monitored-game list and idle threshold."""
+        if user_input is not None:
+            raw = user_input.get(CONF_MONITORED_GAMES, "") or ""
+            self._monitored = {
+                line.strip() for line in raw.splitlines() if line.strip()
+            }
+            self._idle_threshold = user_input[CONF_GAMING_IDLE_THRESHOLD]
+            return self._save()
+
         options = {
             vol.Optional(
                 CONF_MONITORED_GAMES,
-                default=self.config_entry.options.get(CONF_MONITORED_GAMES, ""),
+                default=self._serialize_monitored(),
             ): selector.TextSelector(
                 selector.TextSelectorConfig(
                     type=selector.TextSelectorType.TEXT,
@@ -175,13 +322,11 @@ class RetroAchievementsOptionsFlowHandler(config_entries.OptionsFlow):
             ),
             vol.Optional(
                 CONF_GAMING_IDLE_THRESHOLD,
-                default=self.config_entry.options.get(
-                    CONF_GAMING_IDLE_THRESHOLD, DEFAULT_GAMING_IDLE_THRESHOLD
-                ),
+                default=self._idle_threshold,
             ): vol.All(vol.Coerce(int), vol.Range(min=1, max=60)),
         }
-
         return self.async_show_form(
-            step_id="init",
+            step_id="manage",
             data_schema=vol.Schema(options),
+            errors={"base": error} if error else None,
         )

--- a/custom_components/retroarchievements/const.py
+++ b/custom_components/retroarchievements/const.py
@@ -14,6 +14,7 @@ PLATFORMS = [
     Platform.IMAGE,
     Platform.TODO,
     Platform.BUTTON,
+    Platform.CALENDAR,
 ]
 
 # API
@@ -47,6 +48,9 @@ ATTRIBUTION = "Data provided by RetroAchievements"
 # Options
 CONF_GAMING_IDLE_THRESHOLD = "gaming_idle_threshold"
 DEFAULT_GAMING_IDLE_THRESHOLD = 5  # minutes
+
+# Number of trailing days of unlock history exposed via the calendar entity.
+EARNED_HISTORY_DAYS = 14
 
 # Services
 SERVICE_REFRESH = "refresh"

--- a/custom_components/retroarchievements/coordinator.py
+++ b/custom_components/retroarchievements/coordinator.py
@@ -15,6 +15,7 @@ from .const import (
     CONF_GAMING_IDLE_THRESHOLD,
     DEFAULT_GAMING_IDLE_THRESHOLD,
     DOMAIN,
+    EARNED_HISTORY_DAYS,
     EVENT_ACHIEVEMENT_UNLOCKED,
     EVENT_AOTW_CHANGED,
     EVENT_AWARD_EARNED,
@@ -221,7 +222,11 @@ class RetroAchievementsDataUpdateCoordinator(DataUpdateCoordinator):
 
     async def _async_update_data(self) -> dict:
         try:
-            today = dt_util.now().strftime("%Y-%m-%d")
+            now = dt_util.now()
+            today = now.strftime("%Y-%m-%d")
+            history_start = (now - timedelta(days=EARNED_HISTORY_DAYS)).strftime(
+                "%Y-%m-%d"
+            )
             (
                 user_summary,
                 game_data,
@@ -236,6 +241,7 @@ class RetroAchievementsDataUpdateCoordinator(DataUpdateCoordinator):
                 set_requests,
                 earned_on_day,
                 recent_game_awards,
+                earned_between,
             ) = await asyncio.gather(
                 self.api_client.async_get_user_summary(),
                 self._get_game_data(),
@@ -268,6 +274,12 @@ class RetroAchievementsDataUpdateCoordinator(DataUpdateCoordinator):
                 ),
                 self._safe_get(
                     self.api_client.async_get_recent_game_awards, "recent game awards"
+                ),
+                self._safe_get_list(
+                    lambda: self.api_client.async_get_achievements_earned_between(
+                        history_start, today
+                    ),
+                    "achievements earned between",
                 ),
             )
 
@@ -320,6 +332,7 @@ class RetroAchievementsDataUpdateCoordinator(DataUpdateCoordinator):
                 "set_requests": set_requests,
                 "earned_on_day": earned_on_day,
                 "recent_game_awards": recent_game_awards,
+                "earned_between": earned_between,
                 **game_data,
             }
         except Exception as error:
@@ -399,7 +412,7 @@ class RetroAchievementsDataUpdateCoordinator(DataUpdateCoordinator):
 
         self.monitored_games = monitored_game_ids
 
-        game_data = {"Awarded": {}, "Leaderboards": {}}
+        game_data = {"Awarded": {}, "Leaderboards": {}, "RankScore": {}}
         if not monitored_game_ids:
             return game_data
 
@@ -412,9 +425,14 @@ class RetroAchievementsDataUpdateCoordinator(DataUpdateCoordinator):
             self.api_client.async_get_user_game_leaderboards(game_id)
             for game_id in game_ids
         ]
+        rank_score_tasks = [
+            self.api_client.async_get_user_game_rank_and_score(game_id)
+            for game_id in game_ids
+        ]
 
         game_progresses = await asyncio.gather(*progress_tasks, return_exceptions=True)
         leaderboards = await asyncio.gather(*leaderboard_tasks, return_exceptions=True)
+        rank_scores = await asyncio.gather(*rank_score_tasks, return_exceptions=True)
 
         for i, game_id in enumerate(game_ids):
             game_id_str = str(game_id)
@@ -434,5 +452,15 @@ class RetroAchievementsDataUpdateCoordinator(DataUpdateCoordinator):
                 )
             elif isinstance(leaderboard, dict):
                 game_data["Leaderboards"][game_id_str] = leaderboard
+
+            rank_score = rank_scores[i]
+            if isinstance(rank_score, Exception):
+                LOGGER.warning(
+                    "Error fetching rank/score for game_id=%s: %s",
+                    game_id,
+                    rank_score,
+                )
+            elif isinstance(rank_score, list) and rank_score:
+                game_data["RankScore"][game_id_str] = rank_score[0]
 
         return game_data

--- a/custom_components/retroarchievements/manifest.json
+++ b/custom_components/retroarchievements/manifest.json
@@ -11,5 +11,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/hudsonbrendon/HA-retroachievements/issues",
   "requirements": [],
-  "version": "0.6.0"
+  "version": "0.7.0"
 }

--- a/custom_components/retroarchievements/sensor.py
+++ b/custom_components/retroarchievements/sensor.py
@@ -54,6 +54,31 @@ _SOCIAL_KEYS = frozenset(
     }
 )
 
+_EXTRA_KEYS = frozenset(
+    {
+        "want_to_play_count",
+        "last_achievement",
+    }
+)
+
+
+def _latest_achievement(coordinator_data: dict) -> dict | None:
+    """Return the most recently unlocked achievement across all games, or None."""
+    recent = (coordinator_data or {}).get("RecentAchievements") or {}
+    latest: dict | None = None
+    for achievements in recent.values():
+        if not isinstance(achievements, dict):
+            continue
+        for achievement in achievements.values():
+            if not isinstance(achievement, dict):
+                continue
+            if latest is None or str(achievement.get("DateAwarded", "")) > str(
+                latest.get("DateAwarded", "")
+            ):
+                latest = achievement
+    return latest
+
+
 USER_SENSORS = [
     SensorEntityDescription(
         key="username",
@@ -192,6 +217,18 @@ USER_SENSORS = [
         icon="mdi:trophy-variant",
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
+    SensorEntityDescription(
+        key="want_to_play_count",
+        translation_key="want_to_play_count",
+        icon="mdi:playlist-star",
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    SensorEntityDescription(
+        key="last_achievement",
+        translation_key="last_achievement",
+        icon="mdi:trophy",
+    ),
 ]
 
 
@@ -321,10 +358,23 @@ class RetroAchievementsUserSensor(RetroAchievementsBaseSensor):
                 recent_game = data["RecentlyPlayed"][0]
                 return f"{recent_game.get('Title')} - {recent_game.get('ConsoleName')}"
             return "None"
-        if self._key in _STAT_KEYS:
-            return self._stat_value()
-        if self._key in _SOCIAL_KEYS:
-            return self._social_value()
+        for keyset, handler in (
+            (_STAT_KEYS, self._stat_value),
+            (_SOCIAL_KEYS, self._social_value),
+            (_EXTRA_KEYS, self._extra_value),
+        ):
+            if self._key in keyset:
+                return handler()
+        return None
+
+    def _extra_value(self):
+        """Return a value for keys derived from already-fetched coordinator data."""
+        data = self.coordinator.data
+        if self._key == "want_to_play_count":
+            return (data.get("want_to_play") or {}).get("Total", 0)
+        if self._key == "last_achievement":
+            latest = _latest_achievement(data)
+            return latest.get("Title") if latest else None
         return None
 
     def _social_value(self):
@@ -407,6 +457,39 @@ class RetroAchievementsUserSensor(RetroAchievementsBaseSensor):
         if self._key in _SOCIAL_KEYS:
             return self._social_attributes()
 
+        if self._key in _EXTRA_KEYS:
+            return self._extra_attributes()
+
+        return {}
+
+    def _extra_attributes(self):
+        """Return state attributes for the derived extra sensors."""
+        data = self.coordinator.data
+        if self._key == "want_to_play_count":
+            return {"games": (data.get("want_to_play") or {}).get("Results", [])}
+        if self._key == "last_achievement":
+            latest = _latest_achievement(data)
+            if not latest:
+                return {}
+            badge = latest.get("BadgeName")
+            return {
+                "id": latest.get("ID"),
+                "title": latest.get("Title"),
+                "description": latest.get("Description"),
+                "points": latest.get("Points"),
+                "game": latest.get("GameTitle"),
+                "date_awarded": latest.get("DateAwarded"),
+                "badge_url": (
+                    f"https://retroachievements.org/Badge/{badge}.png"
+                    if badge
+                    else None
+                ),
+                "url": (
+                    f"https://retroachievements.org/achievement/{latest.get('ID')}"
+                    if latest.get("ID")
+                    else None
+                ),
+            }
         return {}
 
     def _social_attributes(self):
@@ -615,6 +698,15 @@ class RetroAchievementsGameSensor(RetroAchievementsBaseSensor):
         )
         if results:
             attrs["leaderboards"] = results
+        rank_score = (
+            (self.coordinator.data or {})
+            .get("RankScore", {})
+            .get(str(self._game_id), {})
+        )
+        if isinstance(rank_score, dict) and rank_score:
+            attrs["user_rank"] = rank_score.get("UserRank")
+            attrs["user_total_score"] = rank_score.get("TotalScore")
+            attrs["last_award"] = rank_score.get("LastAward")
         return attrs
 
 

--- a/custom_components/retroarchievements/translations/en.json
+++ b/custom_components/retroarchievements/translations/en.json
@@ -370,6 +370,43 @@
             },
             "top_ten": {
                 "name": "Top Ten Leader"
+            },
+            "want_to_play_count": {
+                "name": "Want to Play Count"
+            },
+            "last_achievement": {
+                "name": "Last Achievement",
+                "state_attributes": {
+                    "id": {
+                        "name": "ID"
+                    },
+                    "title": {
+                        "name": "Title"
+                    },
+                    "description": {
+                        "name": "Description"
+                    },
+                    "points": {
+                        "name": "Points"
+                    },
+                    "game": {
+                        "name": "Game"
+                    },
+                    "date_awarded": {
+                        "name": "Date Awarded"
+                    },
+                    "badge_url": {
+                        "name": "Badge URL"
+                    },
+                    "url": {
+                        "name": "Achievement URL"
+                    }
+                }
+            }
+        },
+        "calendar": {
+            "achievements": {
+                "name": "Achievements"
             }
         },
         "binary_sensor": {

--- a/custom_components/retroarchievements/translations/en.json
+++ b/custom_components/retroarchievements/translations/en.json
@@ -34,12 +34,37 @@
         "step": {
             "init": {
                 "title": "RetroAchievements Options",
-                "description": "Configure options for RetroAchievements.",
+                "description": "Choose what to configure.",
+                "menu_options": {
+                    "select_games": "Select games to monitor",
+                    "manage": "Edit game IDs & settings"
+                }
+            },
+            "select_games": {
+                "title": "Select a console",
+                "description": "Pick a console to browse its games.",
+                "data": {
+                    "console": "Console"
+                }
+            },
+            "pick_games": {
+                "title": "Select games",
+                "description": "Choose which games of this console to monitor. Games from other consoles are kept.",
+                "data": {
+                    "games": "Games"
+                }
+            },
+            "manage": {
+                "title": "Game IDs & settings",
+                "description": "Edit the monitored game IDs directly and adjust settings.",
                 "data": {
                     "monitored_games": "Game IDs to monitor (one ID per line)",
                     "gaming_idle_threshold": "Gaming idle threshold (minutes)"
                 }
             }
+        },
+        "error": {
+            "cannot_load_games": "Could not load the game catalog from RetroAchievements. Edit game IDs manually below."
         }
     },
     "entity": {

--- a/custom_components/retroarchievements/translations/pt-BR.json
+++ b/custom_components/retroarchievements/translations/pt-BR.json
@@ -200,6 +200,27 @@
             },
             "top_ten": {
                 "name": "Líder do Top 10"
+            },
+            "want_to_play_count": {
+                "name": "Total Quero Jogar"
+            },
+            "last_achievement": {
+                "name": "Última Conquista",
+                "state_attributes": {
+                    "id": "ID",
+                    "title": "Título",
+                    "description": "Descrição",
+                    "points": "Pontos",
+                    "game": "Jogo",
+                    "date_awarded": "Data de Obtenção",
+                    "badge_url": "URL do Emblema",
+                    "url": "URL da Conquista"
+                }
+            }
+        },
+        "calendar": {
+            "achievements": {
+                "name": "Conquistas"
             }
         },
         "image": {

--- a/custom_components/retroarchievements/translations/pt-BR.json
+++ b/custom_components/retroarchievements/translations/pt-BR.json
@@ -31,11 +31,37 @@
         "step": {
             "init": {
                 "title": "Opções do RetroAchievements",
-                "description": "Configure as opções para o RetroAchievements.",
+                "description": "Escolha o que configurar.",
+                "menu_options": {
+                    "select_games": "Selecionar jogos para monitorar",
+                    "manage": "Editar IDs de jogos e ajustes"
+                }
+            },
+            "select_games": {
+                "title": "Selecionar um console",
+                "description": "Escolha um console para listar seus jogos.",
                 "data": {
-                    "monitored_games": "IDs dos jogos para monitorar (um ID por linha)"
+                    "console": "Console"
+                }
+            },
+            "pick_games": {
+                "title": "Selecionar jogos",
+                "description": "Escolha quais jogos deste console monitorar. Jogos de outros consoles são mantidos.",
+                "data": {
+                    "games": "Jogos"
+                }
+            },
+            "manage": {
+                "title": "IDs de jogos e ajustes",
+                "description": "Edite os IDs dos jogos monitorados diretamente e ajuste as configurações.",
+                "data": {
+                    "monitored_games": "IDs dos jogos para monitorar (um ID por linha)",
+                    "gaming_idle_threshold": "Limite de inatividade de jogo (minutos)"
                 }
             }
+        },
+        "error": {
+            "cannot_load_games": "Não foi possível carregar o catálogo de jogos do RetroAchievements. Edite os IDs manualmente abaixo."
         }
     },
     "entity": {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -105,6 +105,18 @@ def user_game_leaderboards_fixture() -> dict:
 
 
 @pytest.fixture
+def earned_between_fixture() -> list:
+    """Return the sample GetAchievementsEarnedBetween payload."""
+    return load_fixture("earned_between.json")
+
+
+@pytest.fixture
+def game_rank_score_fixture() -> list:
+    """Return the sample GetUserGameRankAndScore payload."""
+    return load_fixture("game_rank_score.json")
+
+
+@pytest.fixture
 def mock_api_client(
     user_summary_fixture,
     aotw_fixture,
@@ -120,6 +132,8 @@ def mock_api_client(
     earned_on_day_fixture,
     recent_game_awards_fixture,
     user_game_leaderboards_fixture,
+    earned_between_fixture,
+    game_rank_score_fixture,
 ):
     """Return an AsyncMock API client preloaded with fixture responses."""
     # Local import to keep the heavy HA import out of fixture-discovery time
@@ -148,4 +162,6 @@ def mock_api_client(
     client.async_get_user_game_leaderboards.return_value = (
         user_game_leaderboards_fixture
     )
+    client.async_get_achievements_earned_between.return_value = earned_between_fixture
+    client.async_get_user_game_rank_and_score.return_value = game_rank_score_fixture
     return client

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -117,6 +117,18 @@ def game_rank_score_fixture() -> list:
 
 
 @pytest.fixture
+def console_ids_fixture() -> list:
+    """Return the sample GetConsoleIDs payload."""
+    return load_fixture("console_ids.json")
+
+
+@pytest.fixture
+def game_list_fixture() -> list:
+    """Return the sample GetGameList payload."""
+    return load_fixture("game_list.json")
+
+
+@pytest.fixture
 def mock_api_client(
     user_summary_fixture,
     aotw_fixture,
@@ -164,4 +176,6 @@ def mock_api_client(
     )
     client.async_get_achievements_earned_between.return_value = earned_between_fixture
     client.async_get_user_game_rank_and_score.return_value = game_rank_score_fixture
+    client.async_get_console_ids.return_value = load_fixture("console_ids.json")
+    client.async_get_game_list.return_value = load_fixture("game_list.json")
     return client

--- a/tests/fixtures/console_ids.json
+++ b/tests/fixtures/console_ids.json
@@ -1,0 +1,5 @@
+[
+  {"ID": 1, "Name": "Mega Drive"},
+  {"ID": 7, "Name": "NES/Famicom"},
+  {"ID": 12, "Name": "PlayStation"}
+]

--- a/tests/fixtures/earned_between.json
+++ b/tests/fixtures/earned_between.json
@@ -1,0 +1,5 @@
+[
+  {"ID": 55401, "Title": "First Steps", "Description": "Start a new game", "GameID": 678, "GameTitle": "Sonic the Hedgehog", "ConsoleName": "Mega Drive", "Points": 5, "BadgeName": "11001", "HardcoreMode": 1, "Date": "2026-05-20 09:00:00"},
+  {"ID": 55402, "Title": "Speed Demon", "Description": "Finish a level fast", "GameID": 678, "GameTitle": "Sonic the Hedgehog", "ConsoleName": "Mega Drive", "Points": 10, "BadgeName": "11002", "HardcoreMode": 1, "Date": "2026-05-20 09:30:00"},
+  {"ID": 55403, "Title": "Brawler", "Description": "Defeat 50 enemies", "GameID": 700, "GameTitle": "Streets of Rage", "ConsoleName": "Mega Drive", "Points": 25, "BadgeName": "11003", "HardcoreMode": 0, "Date": "2026-05-22 18:45:00"}
+]

--- a/tests/fixtures/game_list.json
+++ b/tests/fixtures/game_list.json
@@ -1,0 +1,5 @@
+[
+  {"ID": 678, "Title": "Sonic the Hedgehog", "ConsoleID": 1, "ConsoleName": "Mega Drive", "NumAchievements": 24},
+  {"ID": 700, "Title": "Streets of Rage", "ConsoleID": 1, "ConsoleName": "Mega Drive", "NumAchievements": 30},
+  {"ID": 800, "Title": "Aladdin", "ConsoleID": 1, "ConsoleName": "Mega Drive", "NumAchievements": 20}
+]

--- a/tests/fixtures/game_rank_score.json
+++ b/tests/fixtures/game_rank_score.json
@@ -1,0 +1,3 @@
+[
+  {"User": "TestUser", "UserRank": 3, "TotalScore": 400, "LastAward": "2026-05-20 11:55:00"}
+]

--- a/tests/test_api_new_endpoints.py
+++ b/tests/test_api_new_endpoints.py
@@ -69,3 +69,47 @@ async def test_get_user_points_non_dict_returns_empty(session):
         client = RetroAchievementsApiClient("TestUser", "key", session)
         result = await client.async_get_user_points()
     assert result == {}
+
+
+async def test_get_achievements_earned_between_returns_payload(
+    session, earned_between_fixture
+):
+    url = re.compile(rf"^{re.escape(BASE_URL)}API_GetAchievementsEarnedBetween\.php")
+    with aioresponses() as m:
+        m.get(url, payload=earned_between_fixture)
+        client = RetroAchievementsApiClient("TestUser", "key", session)
+        result = await client.async_get_achievements_earned_between(
+            "2026-05-20", "2026-05-23"
+        )
+    assert len(result) == 3
+    assert result[0]["Title"] == "First Steps"
+
+
+async def test_get_achievements_earned_between_non_list_returns_empty(session):
+    url = re.compile(rf"^{re.escape(BASE_URL)}API_GetAchievementsEarnedBetween\.php")
+    with aioresponses() as m:
+        m.get(url, payload={})
+        client = RetroAchievementsApiClient("TestUser", "key", session)
+        result = await client.async_get_achievements_earned_between("a", "b")
+    assert result == []
+
+
+async def test_get_user_game_rank_and_score_returns_payload(
+    session, game_rank_score_fixture
+):
+    url = re.compile(rf"^{re.escape(BASE_URL)}API_GetUserGameRankAndScore\.php")
+    with aioresponses() as m:
+        m.get(url, payload=game_rank_score_fixture)
+        client = RetroAchievementsApiClient("TestUser", "key", session)
+        result = await client.async_get_user_game_rank_and_score(678)
+    assert result[0]["UserRank"] == 3
+    assert result[0]["TotalScore"] == 400
+
+
+async def test_get_user_game_rank_and_score_non_list_returns_empty(session):
+    url = re.compile(rf"^{re.escape(BASE_URL)}API_GetUserGameRankAndScore\.php")
+    with aioresponses() as m:
+        m.get(url, payload={})
+        client = RetroAchievementsApiClient("TestUser", "key", session)
+        result = await client.async_get_user_game_rank_and_score(678)
+    assert result == []

--- a/tests/test_api_new_endpoints.py
+++ b/tests/test_api_new_endpoints.py
@@ -113,3 +113,41 @@ async def test_get_user_game_rank_and_score_non_list_returns_empty(session):
         client = RetroAchievementsApiClient("TestUser", "key", session)
         result = await client.async_get_user_game_rank_and_score(678)
     assert result == []
+
+
+async def test_get_console_ids_returns_payload(session, console_ids_fixture):
+    url = re.compile(rf"^{re.escape(BASE_URL)}API_GetConsoleIDs\.php")
+    with aioresponses() as m:
+        m.get(url, payload=console_ids_fixture)
+        client = RetroAchievementsApiClient("TestUser", "key", session)
+        result = await client.async_get_console_ids()
+    assert len(result) == 3
+    assert result[0]["Name"] == "Mega Drive"
+
+
+async def test_get_console_ids_non_list_returns_empty(session):
+    url = re.compile(rf"^{re.escape(BASE_URL)}API_GetConsoleIDs\.php")
+    with aioresponses() as m:
+        m.get(url, payload={})
+        client = RetroAchievementsApiClient("TestUser", "key", session)
+        result = await client.async_get_console_ids()
+    assert result == []
+
+
+async def test_get_game_list_returns_payload(session, game_list_fixture):
+    url = re.compile(rf"^{re.escape(BASE_URL)}API_GetGameList\.php")
+    with aioresponses() as m:
+        m.get(url, payload=game_list_fixture)
+        client = RetroAchievementsApiClient("TestUser", "key", session)
+        result = await client.async_get_game_list(1)
+    assert len(result) == 3
+    assert result[0]["ID"] == 678
+
+
+async def test_get_game_list_non_list_returns_empty(session):
+    url = re.compile(rf"^{re.escape(BASE_URL)}API_GetGameList\.php")
+    with aioresponses() as m:
+        m.get(url, payload={})
+        client = RetroAchievementsApiClient("TestUser", "key", session)
+        result = await client.async_get_game_list(1)
+    assert result == []

--- a/tests/test_calendar.py
+++ b/tests/test_calendar.py
@@ -1,0 +1,70 @@
+"""Tests for the RetroAchievements achievements calendar."""
+
+from __future__ import annotations
+
+import pytest
+from homeassistant.util import dt as dt_util
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.retroarchievements.calendar import (
+    RetroAchievementsAchievementsCalendar,
+)
+from custom_components.retroarchievements.const import DOMAIN
+from custom_components.retroarchievements.coordinator import (
+    RetroAchievementsDataUpdateCoordinator,
+)
+
+
+@pytest.fixture
+def mock_entry():
+    return MockConfigEntry(
+        domain=DOMAIN,
+        data={"username": "TestUser", "api_key": "key"},
+        options={},
+        entry_id="cal",
+    )
+
+
+async def test_event_returns_latest_unlock(hass, mock_api_client, mock_entry):
+    coord = RetroAchievementsDataUpdateCoordinator(hass, mock_api_client, mock_entry)
+    await coord.async_refresh()
+    calendar = RetroAchievementsAchievementsCalendar(coord, "TestUser")
+    event = calendar.event
+    # earned_between fixture's latest unlock is "Brawler" on 2026-05-22.
+    assert event is not None
+    assert event.summary == "Brawler (Streets of Rage)"
+
+
+async def test_get_events_filters_by_range(hass, mock_api_client, mock_entry):
+    coord = RetroAchievementsDataUpdateCoordinator(hass, mock_api_client, mock_entry)
+    await coord.async_refresh()
+    calendar = RetroAchievementsAchievementsCalendar(coord, "TestUser")
+
+    start = dt_util.parse_datetime("2026-05-20 00:00:00").replace(
+        tzinfo=dt_util.DEFAULT_TIME_ZONE
+    )
+    end = dt_util.parse_datetime("2026-05-21 00:00:00").replace(
+        tzinfo=dt_util.DEFAULT_TIME_ZONE
+    )
+    events = await calendar.async_get_events(hass, start, end)
+    # Only the two May-20 unlocks fall in this window.
+    assert len(events) == 2
+    assert {e.summary for e in events} == {
+        "First Steps (Sonic the Hedgehog)",
+        "Speed Demon (Sonic the Hedgehog)",
+    }
+
+
+async def test_get_events_empty_when_no_history(hass, mock_api_client, mock_entry):
+    mock_api_client.async_get_achievements_earned_between.return_value = []
+    coord = RetroAchievementsDataUpdateCoordinator(hass, mock_api_client, mock_entry)
+    await coord.async_refresh()
+    calendar = RetroAchievementsAchievementsCalendar(coord, "TestUser")
+    assert calendar.event is None
+    start = dt_util.parse_datetime("2026-05-01 00:00:00").replace(
+        tzinfo=dt_util.DEFAULT_TIME_ZONE
+    )
+    end = dt_util.parse_datetime("2026-06-01 00:00:00").replace(
+        tzinfo=dt_util.DEFAULT_TIME_ZONE
+    )
+    assert await calendar.async_get_events(hass, start, end) == []

--- a/tests/test_config_flow_options.py
+++ b/tests/test_config_flow_options.py
@@ -1,6 +1,8 @@
-"""Tests for the options flow with gaming_idle_threshold."""
+"""Tests for the options flow: menu, manage step, and game picker."""
 
 from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from homeassistant.data_entry_flow import InvalidData
@@ -8,8 +10,11 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.retroarchievements.const import (
     CONF_GAMING_IDLE_THRESHOLD,
+    CONF_MONITORED_GAMES,
     DOMAIN,
 )
+
+from .conftest import load_fixture
 
 
 @pytest.fixture
@@ -24,25 +29,118 @@ def mock_entry(hass):
     return entry
 
 
-async def test_options_flow_accepts_idle_threshold(
+@pytest.fixture
+def patched_client():
+    """Patch the config_flow API client with fixture-backed responses."""
+    client = AsyncMock()
+    client.async_get_console_ids.return_value = load_fixture("console_ids.json")
+    client.async_get_game_list.return_value = load_fixture("game_list.json")
+    with patch(
+        "custom_components.retroarchievements.config_flow.RetroAchievementsApiClient",
+        return_value=client,
+    ):
+        yield client
+
+
+async def _open_menu(hass, entry):
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+    assert result["type"] == "menu"
+    return result
+
+
+async def test_manage_step_accepts_idle_threshold(
     hass, mock_entry, enable_custom_integrations
 ):
-    result = await hass.config_entries.options.async_init(mock_entry.entry_id)
+    result = await _open_menu(hass, mock_entry)
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"], user_input={"next_step_id": "manage"}
+    )
     assert result["type"] == "form"
     result2 = await hass.config_entries.options.async_configure(
         result["flow_id"],
-        user_input={"monitored_games": "", CONF_GAMING_IDLE_THRESHOLD: 10},
+        user_input={CONF_MONITORED_GAMES: "", CONF_GAMING_IDLE_THRESHOLD: 10},
     )
     assert result2["type"] == "create_entry"
     assert result2["data"][CONF_GAMING_IDLE_THRESHOLD] == 10
 
 
-async def test_options_flow_rejects_threshold_too_high(
+async def test_manage_step_rejects_threshold_too_high(
     hass, mock_entry, enable_custom_integrations
 ):
-    result = await hass.config_entries.options.async_init(mock_entry.entry_id)
+    result = await _open_menu(hass, mock_entry)
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"], user_input={"next_step_id": "manage"}
+    )
     with pytest.raises(InvalidData):
         await hass.config_entries.options.async_configure(
             result["flow_id"],
-            user_input={"monitored_games": "", CONF_GAMING_IDLE_THRESHOLD: 999},
+            user_input={CONF_MONITORED_GAMES: "", CONF_GAMING_IDLE_THRESHOLD: 999},
         )
+
+
+async def test_picker_selects_games(
+    hass, mock_entry, enable_custom_integrations, patched_client
+):
+    result = await _open_menu(hass, mock_entry)
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"], user_input={"next_step_id": "select_games"}
+    )
+    assert result["type"] == "form"
+    assert result["step_id"] == "select_games"
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"], user_input={"console": "1"}
+    )
+    assert result["type"] == "form"
+    assert result["step_id"] == "pick_games"
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"], user_input={"games": ["678", "700"]}
+    )
+    assert result["type"] == "create_entry"
+    assert set(result["data"][CONF_MONITORED_GAMES].split()) == {"678", "700"}
+
+
+async def test_picker_preserves_other_console_games(
+    hass, enable_custom_integrations, patched_client
+):
+    # 999 belongs to a console not in the fixture game list; it must survive.
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"username": "TestUser", "api_key": "k"},
+        options={CONF_MONITORED_GAMES: "999\n800"},
+        entry_id="t2",
+    )
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"], user_input={"next_step_id": "select_games"}
+    )
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"], user_input={"console": "1"}
+    )
+    # Deselect 800, select 678 instead. 999 (other console) preserved.
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"], user_input={"games": ["678"]}
+    )
+    assert result["type"] == "create_entry"
+    assert set(result["data"][CONF_MONITORED_GAMES].split()) == {"678", "999"}
+
+
+async def test_select_games_falls_back_to_manage_without_consoles(
+    hass, mock_entry, enable_custom_integrations
+):
+    client = AsyncMock()
+    client.async_get_console_ids.return_value = []
+    with patch(
+        "custom_components.retroarchievements.config_flow.RetroAchievementsApiClient",
+        return_value=client,
+    ):
+        result = await _open_menu(hass, mock_entry)
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"], user_input={"next_step_id": "select_games"}
+        )
+    assert result["type"] == "form"
+    assert result["step_id"] == "manage"
+    assert result["errors"] == {"base": "cannot_load_games"}

--- a/tests/test_sensor_extra.py
+++ b/tests/test_sensor_extra.py
@@ -1,0 +1,96 @@
+"""Tests for the derived extra sensors (want_to_play_count, last_achievement)."""
+
+from __future__ import annotations
+
+import pytest
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.retroarchievements.const import DOMAIN
+from custom_components.retroarchievements.coordinator import (
+    RetroAchievementsDataUpdateCoordinator,
+)
+from custom_components.retroarchievements.sensor import (
+    USER_SENSORS,
+    RetroAchievementsGameSensor,
+    RetroAchievementsUserSensor,
+)
+
+
+@pytest.fixture
+def mock_entry():
+    return MockConfigEntry(
+        domain=DOMAIN,
+        data={"username": "TestUser", "api_key": "key"},
+        options={},
+        entry_id="x",
+    )
+
+
+@pytest.fixture
+def mock_entry_with_game():
+    return MockConfigEntry(
+        domain=DOMAIN,
+        data={"username": "TestUser", "api_key": "key"},
+        options={"monitored_games": "678"},
+        entry_id="xg",
+    )
+
+
+def _description(key: str):
+    for description in USER_SENSORS:
+        if description.key == key:
+            return description
+    msg = f"no USER_SENSORS description with key {key!r}"
+    raise AssertionError(msg)
+
+
+async def test_want_to_play_count_value_and_attrs(hass, mock_api_client, mock_entry):
+    coord = RetroAchievementsDataUpdateCoordinator(hass, mock_api_client, mock_entry)
+    await coord.async_refresh()
+    sensor = RetroAchievementsUserSensor(
+        coord, "TestUser", _description("want_to_play_count")
+    )
+    assert sensor.native_value == 2
+    assert len(sensor.extra_state_attributes["games"]) == 2
+
+
+async def test_last_achievement_value_and_attrs(hass, mock_api_client, mock_entry):
+    coord = RetroAchievementsDataUpdateCoordinator(hass, mock_api_client, mock_entry)
+    await coord.async_refresh()
+    sensor = RetroAchievementsUserSensor(
+        coord, "TestUser", _description("last_achievement")
+    )
+    assert sensor.native_value == "First Blood"
+    attrs = sensor.extra_state_attributes
+    assert attrs["id"] == 12345
+    assert attrs["game"] == "Sonic the Hedgehog"
+    assert attrs["badge_url"].endswith("/Badge/01234.png")
+
+
+async def test_last_achievement_handles_no_recent(hass, mock_api_client, mock_entry):
+    mock_api_client.async_get_user_summary.return_value = {
+        "RecentlyPlayed": [],
+        "RecentAchievements": {},
+    }
+    coord = RetroAchievementsDataUpdateCoordinator(hass, mock_api_client, mock_entry)
+    await coord.async_refresh()
+    sensor = RetroAchievementsUserSensor(
+        coord, "TestUser", _description("last_achievement")
+    )
+    assert sensor.native_value is None
+    assert sensor.extra_state_attributes == {}
+
+
+async def test_game_sensor_exposes_rank_and_score(
+    hass, mock_api_client, mock_entry_with_game
+):
+    coord = RetroAchievementsDataUpdateCoordinator(
+        hass, mock_api_client, mock_entry_with_game
+    )
+    await coord.async_refresh()
+    sensor = RetroAchievementsGameSensor(
+        coord, "TestUser", {"GameID": 678, "Title": "Sonic", "ConsoleName": "MD"}
+    )
+    attrs = sensor.extra_state_attributes
+    assert attrs["user_rank"] == 3
+    assert attrs["user_total_score"] == 400


### PR DESCRIPTION
## Resumo

Expande a cobertura da integração com novas entidades e um picker de jogos no fluxo de opções. Tudo aditivo e compatível com o storage atual (`monitored_games` como IDs por linha). Versão `0.6.0` → `0.7.0`.

## Novas entidades

| Entidade | Origem |
|---|---|
| `calendar.<user>_achievements` | `GetAchievementsEarnedBetween` — 1 evento por conquista, últimos 14 dias |
| `sensor.<user>_want_to_play_count` | backlog (dado já buscado, antes só no todo) |
| `sensor.<user>_last_achievement` | última conquista + attrs (badge, pontos, jogo, data, URL) |
| attrs `user_rank` / `user_total_score` / `last_award` no game sensor | `GetUserGameRankAndScore` (jogos monitorados) |

## Picker de jogos no options flow

O campo de texto de IDs vira um **menu**:
- **Selecionar jogos** → escolhe console (`GetConsoleIDs`) → multi-select dos jogos do console (`GetGameList`, só jogos com conquistas, dropdown buscável). Selecionar num console preserva jogos de outros.
- **Editar IDs & ajustes** → textarea de IDs (remoção/bulk/fallback) + idle threshold.
- Fallback para `manage` com erro `cannot_load_games` se o catálogo não carregar.

## Endpoints adicionados ao client

`GetAchievementsEarnedBetween`, `GetUserGameRankAndScore`, `GetConsoleIDs`, `GetGameList`.

## Testes

- Testes de API para os 4 endpoints novos (+ fixtures)
- Sensores: `want_to_play_count`, `last_achievement`, rank/score no game sensor
- Calendar: evento atual, filtro por intervalo, histórico vazio
- Options flow: menu→manage, threshold inválido, picker completo, preservação cross-console, fallback sem catálogo
- **100 testes passam**, `ruff check` + `ruff format` limpos
- Traduções en + pt-BR atualizadas, README documentado

🤖 Generated with [Claude Code](https://claude.com/claude-code)