### PR TITLE
fix: stop re-notifying old achievements on window churn

### DIFF
--- a/custom_components/retroarchievements/coordinator.py
+++ b/custom_components/retroarchievements/coordinator.py
@@ -312,9 +312,17 @@ class RetroAchievementsDataUpdateCoordinator(DataUpdateCoordinator):
                     except Exception as fire_err:  # pylint: disable=broad-except
                         LOGGER.warning("Failed to fire award_earned: %s", fire_err)
 
-            self._previous_achievement_ids = current_ids
+            # Accumulate seen IDs/keys instead of replacing them with the
+            # current poll. GetUserSummary only returns the most recent few
+            # achievements, so the window shifts and can transiently shrink
+            # (empty/partial API response). A plain replacement would drop the
+            # dropped-out IDs from the baseline and re-detect them as "new" when
+            # the window refilled, re-firing notifications for old achievements.
+            # Union keeps the baseline monotonic, so each unlock fires at most
+            # once for the coordinator's lifetime.
+            self._previous_achievement_ids |= current_ids
             self._previous_aotw_id = aotw_id
-            self._previous_award_keys = current_award_keys
+            self._previous_award_keys |= current_award_keys
             self._first_run = False
 
             return {

--- a/custom_components/retroarchievements/manifest.json
+++ b/custom_components/retroarchievements/manifest.json
@@ -11,5 +11,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/hudsonbrendon/HA-retroachievements/issues",
   "requirements": [],
-  "version": "0.7.0"
+  "version": "0.7.1"
 }

--- a/tests/test_coordinator_events.py
+++ b/tests/test_coordinator_events.py
@@ -100,6 +100,43 @@ async def test_no_new_achievements_fires_no_events(hass, mock_api_client, mock_e
     assert fired == []
 
 
+async def test_window_churn_does_not_refire_old_achievement(
+    hass, mock_api_client, mock_entry, user_summary_fixture
+):
+    """A transient empty RecentAchievements window must not refire old IDs.
+
+    Regression: GetUserSummary returns only the 5 most recent achievements.
+    If a poll transiently returns an empty/partial window and a later poll
+    refills it, the old achievement IDs must NOT be re-detected as new.
+    """
+    fired = []
+    hass.bus.async_listen(EVENT_ACHIEVEMENT_UNLOCKED, lambda e: fired.append(e))
+
+    coord = RetroAchievementsDataUpdateCoordinator(hass, mock_api_client, mock_entry)
+
+    # First refresh: baseline contains achievement 12345
+    await coord.async_refresh()
+    await hass.async_block_till_done()
+    assert fired == []
+
+    # Second refresh: transient empty window (API hiccup / no recent data)
+    mock_api_client.async_get_user_summary.return_value = {
+        **user_summary_fixture,
+        "RecentAchievements": {},
+    }
+    await coord.async_refresh()
+    await hass.async_block_till_done()
+    assert fired == []
+
+    # Third refresh: window refills with the SAME old achievement
+    mock_api_client.async_get_user_summary.return_value = user_summary_fixture
+    await coord.async_refresh()
+    await hass.async_block_till_done()
+
+    # Old achievement 12345 must NOT refire
+    assert fired == []
+
+
 async def test_aotw_change_fires_event(hass, mock_api_client, mock_entry, aotw_fixture):
     fired = []
     hass.bus.async_listen(EVENT_AOTW_CHANGED, lambda e: fired.append(e))


### PR DESCRIPTION
## Problem

Users received repeated notifications for **old** achievements they had already unlocked. An automation listening to `retroarchievements_achievement_unlocked` kept firing for achievements earned days/weeks ago.

## Root cause

`GetUserSummary` only returns the most recent few achievements (`a=5`), so the `RecentAchievements` window shifts and can transiently **shrink** — e.g. a partial/empty API response or a quiet period.

The coordinator **replaced** its seen-ID baseline with each poll's window:

```python
self._previous_achievement_ids = current_ids
```

So when the window shrank then refilled, the dropped-out IDs left the baseline and were re-detected as `new_ids = current_ids - previous`, re-firing `achievement_unlocked` for already-old achievements. Same flaw for `_previous_award_keys`.

## Fix

Accumulate seen IDs/keys with a union so the baseline is monotonic — each unlock fires at most once per coordinator lifetime, immune to window churn:

```python
self._previous_achievement_ids |= current_ids
self._previous_award_keys |= current_award_keys
```

## Tests

- New regression test: baseline → empty window → refill must **not** re-fire the old achievement.
- Full suite: 101 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where achievements could be re-detected and re-notified when the API temporarily returned incomplete data during refresh cycles.

* **Tests**
  * Added a test to verify achievements are not re-notified on transient API data changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->