### PR TITLE
fix: throttle RA API usage — stop 429 storm, clean coordinator errors

### DIFF
--- a/custom_components/retroarchievements/api.py
+++ b/custom_components/retroarchievements/api.py
@@ -2,13 +2,14 @@
 
 from __future__ import annotations
 
+import asyncio
 import socket
 from typing import Any
 
 import aiohttp
 import async_timeout
 
-from .const import BASE_URL
+from .const import BASE_URL, MAX_CONCURRENT_REQUESTS
 
 
 class RetroAchievementsApiClientError(Exception):
@@ -27,6 +28,12 @@ class RetroAchievementsApiClientAuthenticationError(
     """Exception to indicate an authentication error."""
 
 
+class RetroAchievementsApiClientRateLimitError(
+    RetroAchievementsApiClientCommunicationError,
+):
+    """Exception to indicate the API rate limit was hit (HTTP 429)."""
+
+
 class RetroAchievementsApiClient:
     """RetroAchievements API Client."""
 
@@ -40,6 +47,9 @@ class RetroAchievementsApiClient:
         self._username = username
         self._api_key = api_key
         self._session = session
+        # Serialize bursts: the coordinator fans out many calls per refresh
+        # and the RA edge throttles aggressively (429).
+        self._semaphore = asyncio.Semaphore(MAX_CONCURRENT_REQUESTS)
 
     @property
     def username(self) -> str:
@@ -291,12 +301,16 @@ class RetroAchievementsApiClient:
         url = f"{BASE_URL}{endpoint}"
 
         try:
-            async with async_timeout.timeout(10):
+            async with self._semaphore, async_timeout.timeout(30):
                 response = await self._session.get(url=url, params=params)
 
                 if response.status == 401:
                     raise RetroAchievementsApiClientAuthenticationError(
                         "Invalid API key or username",
+                    )
+                if response.status == 429:
+                    raise RetroAchievementsApiClientRateLimitError(
+                        "Rate limited by the RetroAchievements API (429)",
                     )
                 response.raise_for_status()
 
@@ -309,6 +323,8 @@ class RetroAchievementsApiClient:
 
                 return data
 
+        except RetroAchievementsApiClientError:
+            raise
         except TimeoutError as exception:
             msg = f"Timeout error fetching information - {exception}"
             raise RetroAchievementsApiClientCommunicationError(

--- a/custom_components/retroarchievements/const.py
+++ b/custom_components/retroarchievements/const.py
@@ -27,8 +27,15 @@ CONF_MONITORED_GAMES = "monitored_games"
 
 # Defaults
 DEFAULT_NAME = "RetroAchievements"
-DEFAULT_SCAN_INTERVAL = 1  # minutes
-UPDATE_INTERVAL = 60  # seconds (1 minute in seconds)
+DEFAULT_SCAN_INTERVAL = 5  # minutes
+# Each refresh fans out into ~14 API calls (plus 3 per monitored game); the
+# RetroAchievements API rate-limits aggressively, so polling faster than this
+# produces sustained 429 storms.
+UPDATE_INTERVAL = 300  # seconds
+
+# Maximum concurrent requests against the RetroAchievements API. Their edge
+# throttles bursts well below the per-minute quota, so keep this low.
+MAX_CONCURRENT_REQUESTS = 2
 
 # Entity attributes
 ATTR_GAME_ID = "game_id"

--- a/custom_components/retroarchievements/coordinator.py
+++ b/custom_components/retroarchievements/coordinator.py
@@ -7,10 +7,10 @@ from datetime import timedelta
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from homeassistant.util import dt as dt_util
 
-from .api import RetroAchievementsApiClient
+from .api import RetroAchievementsApiClient, RetroAchievementsApiClientError
 from .const import (
     CONF_GAMING_IDLE_THRESHOLD,
     DEFAULT_GAMING_IDLE_THRESHOLD,
@@ -343,6 +343,11 @@ class RetroAchievementsDataUpdateCoordinator(DataUpdateCoordinator):
                 "earned_between": earned_between,
                 **game_data,
             }
+        except RetroAchievementsApiClientError as error:
+            # Communication/rate-limit errors are expected operational
+            # failures: surface them as UpdateFailed so the coordinator logs
+            # a single clean message instead of a full traceback every cycle.
+            raise UpdateFailed(str(error)) from error
         except Exception as error:
             LOGGER.error("Unexpected error fetching retroachievements data: %s", error)
             raise

--- a/custom_components/retroarchievements/manifest.json
+++ b/custom_components/retroarchievements/manifest.json
@@ -11,5 +11,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/hudsonbrendon/HA-retroachievements/issues",
   "requirements": [],
-  "version": "0.7.1"
+  "version": "0.7.2"
 }


### PR DESCRIPTION
## Problema
Em produção (HA 2026.7.0) o coordinator gerava **milhares de erros**: 11.779× `429 Too Many Requests`, 4.497× timeouts e 1.820× tracebacks "Unexpected error fetching retroarchievements data".

Causa: cada refresh dispara ~14 chamadas em paralelo (+3 por jogo monitorado) a cada **60s**, sem limite de concorrência nem tratamento de 429.

## Correções
- `UPDATE_INTERVAL` 60s → 300s
- Semáforo limitando a 2 requisições concorrentes
- HTTP 429 → `RetroAchievementsApiClientRateLimitError` dedicada
- Erros próprios não são mais re-embrulhados como "Something really wrong happened!"
- Coordinator converte erros do client em `UpdateFailed` (1 linha de log, sem traceback)
- Timeout por requisição 10s → 30s

## Testes
`101 passed` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of API rate limits so temporary “too many requests” responses are reported more clearly.
  * Reduced the chance of failed updates by limiting concurrent requests and giving external requests more time to complete.
  * Updated polling intervals to check for changes less frequently, helping avoid unnecessary request spikes.
* **Chores**
  * Updated the add-on version to 0.7.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->